### PR TITLE
ignore hidden files in base image dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__
+
+/ErrorLog.txt
+
+AlignedPhotos/**
+!AlignedPhotos/DELETETHIS.txt
+
+BaseImages/**
+!BaseImages/DELETETHIS.txt
+
+DailyPhotos/**
+!DailyPhotos/DELETETHIS.txt

--- a/main.py
+++ b/main.py
@@ -30,12 +30,16 @@ class FileManager: #toDO: find a better classname for the filemanager
     def __init__(self,file):
         self.file 
 
+files = os.listdir(Path(BaseImagePath))
+files = list(filter(lambda a: not a.startswith("."), files))
 
-for file in os.listdir(Path(BaseImagePath)):
-    if len(os.listdir(Path(BaseImagePath))) > 1:
-        raise Exception("Ensure there's only one base image, and that you deleted the initial text file.")
-    libfile = PurePath(BaseImagePath+file)
-    BaseImage = classes.BaseImage(libfile)
+if len(files) > 1:
+    raise Exception("Ensure there's only one base image, and that you deleted the initial text file.")
+
+file = files[0]
+
+libfile = PurePath(BaseImagePath+file)
+BaseImage = classes.BaseImage(libfile)
 
 ###RUNNING CODE
 


### PR DESCRIPTION
on macos there are hidden files like `.DS_STORE` by default, this will break the previous detection of the base image, in this PR we filter them out and pick the first match